### PR TITLE
fix: convert performance threshold violations to warnings (fixes #38)

### DIFF
--- a/src/kuzu_memory/core/config.py
+++ b/src/kuzu_memory/core/config.py
@@ -7,6 +7,7 @@ for both programmatic and file-based configuration.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -92,7 +93,7 @@ class ExtractionConfig:
 class PerformanceConfig:
     """Performance monitoring and limits."""
 
-    max_recall_time_ms: float = 200.0
+    max_recall_time_ms: float = 5000.0
     max_generation_time_ms: float = 1000.0  # Increased to 1 second for async operations
     enable_performance_monitoring: bool = True
     log_slow_operations: bool = True
@@ -289,6 +290,14 @@ class KuzuMemoryConfig:
                 for key, value in performance_data.items():
                     if hasattr(performance_config, key):
                         setattr(performance_config, key, value)
+
+            # Allow environment variable override for max_recall_time_ms
+            env_threshold = os.environ.get("KUZU_MEMORY_MAX_RECALL_TIME_MS")
+            if env_threshold:
+                try:
+                    performance_config.max_recall_time_ms = float(env_threshold)
+                except ValueError:
+                    pass  # ignore malformed env var
 
             retention_config = RetentionConfig()
             if "retention" in validated_config:

--- a/src/kuzu_memory/core/memory.py
+++ b/src/kuzu_memory/core/memory.py
@@ -453,16 +453,13 @@ class KuzuMemory:
             execution_time_ms = (time.time() - start_time) * 1000
             self._update_attach_stats(execution_time_ms, len(context.memories))
 
-            # Check performance requirement
+            # Check performance requirement — warn only, never block valid results
             if execution_time_ms > self.config.performance.max_recall_time_ms:
-                if self.config.performance.enable_performance_monitoring:
-                    raise PerformanceError(
-                        f"attach_memories took {execution_time_ms:.1f}ms, exceeding target of {self.config.performance.max_recall_time_ms}ms"
-                    )
-                else:
-                    logger.warning(
-                        f"attach_memories took {execution_time_ms:.1f}ms (target: {self.config.performance.max_recall_time_ms}ms)"
-                    )
+                logger.warning(
+                    f"attach_memories took {execution_time_ms:.1f}ms, "
+                    f"exceeding threshold of {self.config.performance.max_recall_time_ms}ms "
+                    "(results returned)"
+                )
 
             logger.debug(
                 f"attach_memories completed in {execution_time_ms:.1f}ms with {len(context.memories)} memories"
@@ -610,16 +607,13 @@ class KuzuMemory:
             execution_time_ms = (time.time() - start_time) * 1000
             self._update_generate_stats(execution_time_ms, len(memory_ids))
 
-            # Check performance requirement
+            # Check performance requirement — warn only, never block valid results
             if execution_time_ms > self.config.performance.max_generation_time_ms:
-                if self.config.performance.enable_performance_monitoring:
-                    raise PerformanceError(
-                        f"generate_memories took {execution_time_ms:.1f}ms, exceeding target of {self.config.performance.max_generation_time_ms}ms"
-                    )
-                else:
-                    logger.warning(
-                        f"generate_memories took {execution_time_ms:.1f}ms (target: {self.config.performance.max_generation_time_ms}ms)"
-                    )
+                logger.warning(
+                    f"generate_memories took {execution_time_ms:.1f}ms, "
+                    f"exceeding threshold of {self.config.performance.max_generation_time_ms}ms "
+                    "(results returned)"
+                )
 
             logger.debug(
                 f"generate_memories completed in {execution_time_ms:.1f}ms with {len(memory_ids)} memories"

--- a/src/kuzu_memory/recall/coordinator.py
+++ b/src/kuzu_memory/recall/coordinator.py
@@ -17,7 +17,7 @@ from ..core.config import KuzuMemoryConfig
 from ..core.models import Memory, MemoryContext, MemoryType
 from ..storage.cache import MemoryCache
 from ..storage.kuzu_adapter import KuzuAdapter
-from ..utils.exceptions import PerformanceError, PerformanceThresholdError, RecallError
+from ..utils.exceptions import PerformanceError, RecallError
 from ..utils.validation import validate_text_input
 from .strategies import EntityRecallStrategy, KeywordRecallStrategy, TemporalRecallStrategy
 from .temporal_decay import TemporalDecayEngine
@@ -275,15 +275,16 @@ class RecallCoordinator:
             # Update statistics
             self._update_coordinator_stats(strategy_used, context.recall_time_ms)
 
-            # Check performance requirement
+            # Check performance requirement — warn only, never discard valid results
             if (
                 self.config.performance.enable_performance_monitoring
                 and context.recall_time_ms > self.config.performance.max_recall_time_ms
             ):
-                raise PerformanceThresholdError(
-                    operation="attach_memories",
-                    actual_time=context.recall_time_ms / 1000.0,  # Convert to seconds
-                    threshold=self.config.performance.max_recall_time_ms / 1000.0,
+                logger.warning(
+                    "attach_memories exceeded performance threshold: "
+                    f"{context.recall_time_ms:.1f}ms > "
+                    f"{self.config.performance.max_recall_time_ms:.0f}ms "
+                    "(results returned)"
                 )
 
             logger.debug(

--- a/src/kuzu_memory/storage/kuzu_cli_adapter.py
+++ b/src/kuzu_memory/storage/kuzu_cli_adapter.py
@@ -22,7 +22,6 @@ from ..utils.exceptions import (
     DatabaseError,
     DatabaseLockError,
     PerformanceError,
-    PerformanceThresholdError,
 )
 
 logger = logging.getLogger(__name__)
@@ -145,14 +144,15 @@ class KuzuCLIAdapter:
                 # Parse results
                 results = self._parse_output(result.stdout, output_format)
 
-                # Check performance
+                # Check performance — warn only, return results regardless
                 execution_time_ms = (time.time() - start_time) * 1000
                 if (
                     self.config.performance.enable_performance_monitoring
                     and execution_time_ms > timeout_ms
                 ):
-                    raise PerformanceThresholdError(
-                        "execute_query", execution_time_ms / 1000, timeout_ms / 1000
+                    logger.warning(
+                        f"execute_query exceeded threshold: {execution_time_ms:.1f}ms "
+                        f"> {timeout_ms:.0f}ms (results returned)"
                     )
 
                 return results
@@ -163,8 +163,9 @@ class KuzuCLIAdapter:
 
         except subprocess.TimeoutExpired:
             execution_time_ms = (time.time() - start_time) * 1000
-            raise PerformanceThresholdError(
-                "execute_query", execution_time_ms / 1000, timeout_ms / 1000
+            raise DatabaseError(
+                f"execute_query timed out after {execution_time_ms:.0f}ms "
+                f"(limit: {timeout_ms:.0f}ms)"
             )
         except Exception as e:
             if isinstance(e, DatabaseError | PerformanceError):


### PR DESCRIPTION
## Summary

- **Convert hard `PerformanceThresholdError` exceptions to `logger.warning()` calls** in `attach_memories`, recall coordinator, and CLI adapter — results are always returned even when slow
- **Raise default `max_recall_time_ms` from 200ms → 5000ms** to accommodate cold-start embedding model loading (first call was 2.5s in the report)
- **Add `KUZU_MEMORY_MAX_RECALL_TIME_MS` env var override** for per-deployment tuning without config file changes

Fixes #38

## Rationale

Performance monitoring should **observe and warn**, never **discard valid results**. The previous behavior threw away successfully-fetched memories because they took too long to retrieve — the worst possible outcome for a memory system.

## Files changed

| File | Change |
|------|--------|
| `src/kuzu_memory/core/config.py` | Default 200→5000ms, env var override |
| `src/kuzu_memory/core/memory.py` | `raise PerformanceError` → `logger.warning` |
| `src/kuzu_memory/recall/coordinator.py` | `raise PerformanceThresholdError` → `logger.warning` |
| `src/kuzu_memory/storage/kuzu_cli_adapter.py` | `raise PerformanceThresholdError` → `logger.warning` |

## Test plan

- [x] Full test suite: 1649 passed, 66 skipped (2 pre-existing flaky failures unrelated to this change)
- [x] Ruff linting: all checks passed on 4 changed files
- [x] Verified no `raise PerformanceThresholdError` or `raise PerformanceError` remains in changed files
- [x] Verified `KUZU_MEMORY_MAX_RECALL_TIME_MS` env var is wired up with float parsing and error handling
- [x] Live reproduction: `kuzu_recall` was failing with error 4001 before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)